### PR TITLE
Opencv mat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ opencv: example_opencv.cpp
 # Define the rule to clean up generated files
 .PHONY: clean
 clean:
-	rm -f example test
+	rm -f example test example_opencv

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,33 @@ CXX = g++
 SRC = example.cpp
 
 # Define the include directories
-INC_DIRS = -I/usr/local/include/rknpu -I./
+RKNPU_INC_DIR = -I/usr/local/include/rknpu/
+
+OPENCV_INC_DIR = -I/usr/local/include/opencv4/
+
+CURRENT_INC_DIR = -I./
+
+LIB_DIR = -L/usr/local/lib
 
 # Define the libraries to link against
-LIBS = -lrknnrt -fopenmp
+LIBS = -lrknnrt -fopenmp -lopencv_core
 
 # Define the compilation flags
-CXXFLAGS = $(INC_DIRS) $(LIB_DIRS) $(LIBS) -Wall -Wextra -pedantic -O3
+CXX_INCLUDE_FLAGS = $(RKNPU_INC_DIR) $(OPENCV_INC_DIR) $(CURRENT_INC_DIR)
+
+CXX_LIB_FLAGS =  $(LIB_DIR) $(LIBS) 
+
+CXXFLAGS = -Wall -O3
 
 # Define the rule to build the target
 example: example.cpp
-	$(CXX) example.cpp -o example $(CXXFLAGS)
+	$(CXX) example.cpp -o example $(CXX_INCLUDE_FLAGS) $(CXX_LIB_FLAGS) $(CXXFLAGS)
 
 test: test.cpp
-	$(CXX) test.cpp -o test $(CXXFLAGS)
+	$(CXX) test.cpp -o test $(CXX_INCLUDE_FLAGS) $(CXX_LIB_FLAGS) $(CXXFLAGS)
 
+opencv: example_opencv.cpp
+	$(CXX) example_opencv.cpp -o example_opencv $(CXX_INCLUDE_FLAGS) $(CXX_LIB_FLAGS) $(CXXFLAGS)
 # Define the rule to clean up generated files
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This library designed to perform matrix multiplication on a Neural Processing Un
 
 ## Installation
   To install the dependencies of this project, please use the `install.sh` file.
+  If you want to use the opencv features, add --opencv=true `./install.sh --opencv=true` 
   (you may have to `chmod +x` it)
 
 ## Usage
 ```c++
 #include "matrix_types/matrix.hpp"
+#include "matrix_types/opencv_mat.hpp"
 #include <iostream>
 #include <vector>
 
@@ -21,6 +23,7 @@ int main() {
 
     std::vector<int8_t> b(rows*cols, 3);
 
+    // without opencv
     Matrix<int8_t> A(rows, cols, a.data());
     Matrix<int8_t> B(rows, cols, b.data());
 
@@ -28,10 +31,19 @@ int main() {
 
     std::cout << "The first item of the matrix: ";
     std::cout << C.data[0] << "\n";
+
+    //with opencv
+    MatNpu A(rows, cols, CV_8S, a.data());
+    MatNpu B(rows, cols, CV_8S, b.data());
+
+    MatNpu C = A.matmul(B, CV_32S);
+
+    std::cout << "The first item of the matrix: ";
+    std::cout << C.at<int32_t>(0, 0) << "\n";
 }
 ```
 
-<br> Also see the `example.cpp` file which can be compiled using the `Makefile` in the repo. <br>
+<br> Also see the `example.cpp` & `example_opencv.cpp` file which can be compiled using the `Makefile` in the repo. <br>
 
 
 ## Features
@@ -43,8 +55,8 @@ supporting various data types such as `float16`, and `int8_t` as input matrices 
 - Simplifies NPU memory management.
 - Provides utility functions to set matrix data and free resources.
 - Performs efficient matrix multiplication on NPUs.
+- Extention of the [OpenCV](https://github.com/opencv/opencv) Mat
 
 ## Future additions 
-  - Compatibility with the opencv Mat.
   - More operations on the NPU. (Dot Product, convolution, etc..)
   - Rust and Python Bindings.

--- a/api_wrapper/matmul_api.hpp
+++ b/api_wrapper/matmul_api.hpp
@@ -45,8 +45,8 @@ _rknn_matmul_type choose_matmul_type() {
         std::cout << "please enter types from avilable types\n";
         std::cout << "1. float16, float16, float16\n";
         std::cout << "2. float16, float16, float32\n";
-        std::cout << "5. int8_t, int8_t, int32_t\n";
-        std::cout << "6. int8_t, int8_t, int8_t\n";
+        std::cout << "3. int8_t, int8_t, int32_t\n";
+        std::cout << "4. int8_t, int8_t, int8_t\n";
         abort();
     }
 
@@ -186,6 +186,45 @@ tensor_result matmul_npu(
 
     _matmul_ctx* ctx = make_matmul(
         num_rows_a, num_cols_a, num_cols_b, choose_matmul_type<To, Ti1, Ti2>()
+    );
+
+    set_matrix_data(&ctx->ctx, ctx->matrixA, &ctx->io_attr.A, a);
+    set_matrix_data(&ctx->ctx, ctx->matrixB, &ctx->io_attr.B, b);
+    rknn_matmul_run(ctx->ctx);
+
+    tensor_result result(ctx->ctx, ctx->matrixC);
+    free_matmul(ctx);
+
+    return result;
+
+}
+
+
+/**
+ * @brief Performs matrix multiplication on the npu 
+ * 
+ * @param num_rows_a The number of rows in the first input mat
+ * @param num_cols_a The number of columns in the first input mat
+ * @param num_cols_b The number of columns in the second input mat
+ * @param type The matmul type flag
+ * @param a The data of the first input matrix 
+ * @param b The data of the second input matrix 
+ * 
+ * @return _matmul_ctx<To> that has inside the pointer to the result of the matmul.
+ * 
+ * @note The shape of the result is (num_rows_a, num_cols_b)
+ */
+tensor_result matmul_npu(
+    uint32_t num_rows_a,
+    uint32_t num_cols_a,
+    uint32_t num_cols_b,
+    _rknn_matmul_type type,
+    void* a,
+    void* b
+) {
+
+    _matmul_ctx* ctx = make_matmul(
+        num_rows_a, num_cols_a, num_cols_b, type
     );
 
     set_matrix_data(&ctx->ctx, ctx->matrixA, &ctx->io_attr.A, a);

--- a/api_wrapper/matmul_api.hpp
+++ b/api_wrapper/matmul_api.hpp
@@ -138,18 +138,13 @@ _matmul_ctx* make_matmul(
  * @param mem The information of the matrix tensor memory
  * @param attr The attributes of the matrix tensor
  */
-template<typename Ti> 
 void set_matrix_data(
     rknn_matmul_ctx* ctx, 
     rknn_tensor_mem* mem, 
     rknn_matmul_tensor_attr* attr, 
-    const Ti* data ) {
+    const void* data ) {
 
-    size_t size = mem->size / sizeof(Ti);
-    Ti* ptr = (Ti*)mem->virt_addr;
-    for (size_t i = 0; i < size; ++i) {
-        ptr[i] = data[i];
-    }
+    memcpy(mem->virt_addr, data, mem->size);
     rknn_matmul_set_io_mem(*ctx, mem, attr);
 }
 

--- a/api_wrapper/matmul_api.hpp
+++ b/api_wrapper/matmul_api.hpp
@@ -30,6 +30,11 @@ _rknn_matmul_type choose_matmul_type() {
         std::is_same_v<float16, Ti2> && 
         std::is_same_v<float32, To>)  {
         return RKNN_FLOAT16_MM_FLOAT16_TO_FLOAT32;
+    } else if constexpr(
+        std::is_same_v<float16, Ti1> &&
+        std::is_same_v<int8_t, Ti2>  &&
+        std::is_same_v<float16, To> ) { 
+        return RKNN_FLOAT16_MM_INT8_TO_FLOAT16; 
     } else if constexpr (
         std::is_same_v<int8_t, Ti1> && 
         std::is_same_v<int8_t, Ti2> && 
@@ -45,8 +50,9 @@ _rknn_matmul_type choose_matmul_type() {
         std::cout << "please enter types from avilable types\n";
         std::cout << "1. float16, float16, float16\n";
         std::cout << "2. float16, float16, float32\n";
-        std::cout << "3. int8_t, int8_t, int32_t\n";
+        std::cout << "3. float16, int8_t, float16\n";
         std::cout << "4. int8_t, int8_t, int8_t\n";
+        std::cout << "5. int8_t, int8_t, int32_t\n";
         abort();
     }
 

--- a/example_opencv.cpp
+++ b/example_opencv.cpp
@@ -1,0 +1,30 @@
+#include "matrix_types/opencv_mat.hpp"
+#include <iostream>
+#include <vector>
+#include <chrono>
+
+int main() {
+
+    int rows = 4096;
+    int cols = 4096;
+
+    std::vector<int8_t> a(rows*cols, 2);
+
+    std::vector<int8_t> b(rows*cols, 3);
+
+    MatNpu A(rows, cols, CV_8S, a.data());
+    MatNpu B(rows, cols, CV_8S, b.data());
+
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    MatNpu C = A.matmul(B, CV_32S);
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+    std::cout << "Time took: " << elapsed.count() / 1.0E9f << "s\n";
+
+    std::cout << "The first item of the matrix: ";
+    std::cout << C << "\n";
+}

--- a/example_opencv.cpp
+++ b/example_opencv.cpp
@@ -26,5 +26,5 @@ int main() {
     std::cout << "Time took: " << elapsed.count() / 1.0E9f << "s\n";
 
     std::cout << "The first item of the matrix: ";
-    std::cout << C << "\n";
+    std::cout << C.at<int32_t>(0, 0) << "\n";
 }

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,53 @@
 #!/bin/bash
 
+
+INSTALL_OPENCV=false
+
+case "$1" in
+    --opencv=true)
+        INSTALL_OPENCV=true
+        echo "[INFO]: Installing with OpenCv"
+        ;;
+    --opencv=false)
+        INSTALL_OPENCV=false
+        echo "[INFO]: Installing without OpenCv"
+        ;;
+esac
+
+echo "[INFO]: Installing rknn-toolkit2 dependencies"
+
 cd ~    
+sudo apt update -y && sudo apt upgrade -y
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test 
+sudo apt install -y gcc-13 g++-13
+sudo apt install git make libomp-dev
 
-sudo apt update -y 
-
-sudo apt upgrade -y 
-
-sudo apt install git make gcc g++ libomp-dev
+echo "[INFO]: Installing rknn-toolkit2"
 
 git clone --depth=1 https://github.com/airockchip/rknn-toolkit2.git
-
 cd ~/rknn-toolkit2-master/rknpu2/runtime/Linux/librknn_api/aarch64
-
 sudo cp ./librknnrt.so /usr/local/lib
-
 cd ~/rknn-toolkit2-master/rknpu2/runtime/Linux/librknn_api/include
-
 sudo cp ./rknn_* /usr/local/include/rknpu
-
 cd ~
-
 sudo rm -rf ./rknn-toolkit2-master
+
+
+# Check if INSTALL_OPENCV is true and install OpenCV
+if [ "$INSTALL_OPENCV" = true ]; then
+
+    echo "Installing and Building Opencv"
+
+    cd ~
+    sudo apt install cmake
+    sudo apt install -y pkg-config ffmpeg libavformat-dev libavcodec-dev libswscale-dev
+    git clone --depth=1 https://github.com/opencv/opencv.git 
+    cd opencv
+    cmake -B build
+    cd build
+    make -j5
+    sudo make install
+    cd ~ 
+    rm -rf ./opencv
+
+fi

--- a/matrix_types/matrix.hpp
+++ b/matrix_types/matrix.hpp
@@ -1,3 +1,6 @@
+#ifndef MATRIX
+#define MATRIX
+
 #include "api_wrapper/matmul_api.hpp"
 #include <memory>
 
@@ -45,3 +48,4 @@ class Matrix {
 
 };
 
+#endif

--- a/matrix_types/opencv_mat.hpp
+++ b/matrix_types/opencv_mat.hpp
@@ -1,3 +1,6 @@
+#ifndef MATNPU
+#define MATNPU
+
 #include <opencv4/opencv2/opencv.hpp>
 #include "api_wrapper/matmul_api.hpp"
 #include "utils/choose_type.hpp"
@@ -33,3 +36,5 @@ class MatNpu : public cv::Mat {
             );
         }
 };
+
+#endif

--- a/matrix_types/opencv_mat.hpp
+++ b/matrix_types/opencv_mat.hpp
@@ -1,0 +1,35 @@
+#include <opencv4/opencv2/opencv.hpp>
+#include "api_wrapper/matmul_api.hpp"
+#include "utils/choose_type.hpp"
+
+
+class MatNpu : public cv::Mat {
+
+    private: 
+        rknn_tensor_mem* tensor_mem;
+        rknn_context ctx;
+
+        MatNpu(int32_t rows, int32_t cols, int32_t type, void* data, 
+                rknn_tensor_mem* tensor_mem, rknn_context ctx) 
+            : cv::Mat(rows, cols, type, data), tensor_mem(tensor_mem), ctx(ctx) {}
+    
+    public: 
+
+        MatNpu(int32_t rows, int32_t cols, int32_t type, void* data) 
+            : cv::Mat(rows, cols, type, data), tensor_mem(nullptr), ctx(0) {}
+
+
+        ~MatNpu() {
+            rknn_destroy_mem(ctx, tensor_mem);
+            rknn_matmul_destroy(ctx);
+        }
+        
+        MatNpu matmul(MatNpu mat, int32_t output_type) {
+            _rknn_matmul_type mm_type = choose_matmul_type(this->type(), mat.type(), output_type);
+            tensor_result result = matmul_npu(rows, cols, mat.cols, mm_type, data, mat.data);
+            return MatNpu(
+                rows, mat.cols, output_type, result.resultMatrix->virt_addr,
+                result.resultMatrix, result.ctx
+            );
+        }
+};

--- a/utils/choose_type.hpp
+++ b/utils/choose_type.hpp
@@ -1,0 +1,46 @@
+#ifndef CHOOSE_TYPE
+#define CHOOSE_TYPE
+
+#include <rknpu/rknn_matmul_api.h>
+#include <opencv4/opencv2/opencv.hpp>
+
+typedef __fp16 float16;
+typedef float float32;
+
+
+_rknn_matmul_type choose_matmul_type(int input1, int input2, int output) {
+    
+    if (
+        input1 == CV_16F &&
+        input2 == CV_16F &&
+        output == CV_16F ) { 
+        return RKNN_FLOAT16_MM_FLOAT16_TO_FLOAT16; 
+    } else if (
+        input1 == CV_16F &&
+        input2 == CV_8S &&
+        output == CV_16F ) { 
+        return RKNN_FLOAT16_MM_INT8_TO_FLOAT16; 
+    } else if (
+        input1 == CV_16F &&
+        input2 == CV_16F &&
+        output == CV_32F ) { 
+        return RKNN_FLOAT16_MM_FLOAT16_TO_FLOAT32; 
+    } else if (
+        input1 == CV_8S &&
+        input2 == CV_8S &&
+        output == CV_8S) { 
+        return RKNN_INT8_MM_INT8_TO_INT8; 
+    } else {
+        std::cout << "unsupported combination of types:\n";
+        std::cout << "please enter types from avilable types\n";
+        std::cout << "1. float16, float16, float16\n";
+        std::cout << "2. float16, float16, float32\n";
+        std::cout << "5. int8_t, int8_t, int32_t\n";
+        std::cout << "6. int8_t, int8_t, int8_t\n";
+        abort();
+    }
+
+
+}
+
+#endif

--- a/utils/choose_type.hpp
+++ b/utils/choose_type.hpp
@@ -17,29 +17,34 @@ _rknn_matmul_type choose_matmul_type(int input1, int input2, int output) {
         return RKNN_FLOAT16_MM_FLOAT16_TO_FLOAT16; 
     } else if (
         input1 == CV_16F &&
-        input2 == CV_8S &&
-        output == CV_16F ) { 
-        return RKNN_FLOAT16_MM_INT8_TO_FLOAT16; 
-    } else if (
-        input1 == CV_16F &&
         input2 == CV_16F &&
         output == CV_32F ) { 
         return RKNN_FLOAT16_MM_FLOAT16_TO_FLOAT32; 
+    } else if (
+        input1 == CV_16F &&
+        input2 == CV_8S &&
+        output == CV_16F ) { 
+        return RKNN_FLOAT16_MM_INT8_TO_FLOAT16; 
     } else if (
         input1 == CV_8S &&
         input2 == CV_8S &&
         output == CV_8S) { 
         return RKNN_INT8_MM_INT8_TO_INT8; 
+    } else if (
+        input1 == CV_8S &&
+        input2 == CV_8S &&
+        output == CV_32S) { 
+        return RKNN_INT8_MM_INT8_TO_INT32; 
     } else {
         std::cout << "unsupported combination of types:\n";
         std::cout << "please enter types from avilable types\n";
         std::cout << "1. float16, float16, float16\n";
         std::cout << "2. float16, float16, float32\n";
-        std::cout << "5. int8_t, int8_t, int32_t\n";
-        std::cout << "6. int8_t, int8_t, int8_t\n";
+        std::cout << "3. float16, int8_t, float16\n";
+        std::cout << "4. int8_t, int8_t, int8_t\n";
+        std::cout << "4. int8_t, int8_t, int32_t\n";
         abort();
     }
-
 
 }
 


### PR DESCRIPTION
Added a subclass of the opencv Mat called MatNpu, this child class should work with all the opencv operation the requires the Mat class and support the matmul on the NPU 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced OpenCV support for matrix operations, including a new example file `example_opencv.cpp`.
  - Added `MatNpu` class for NPU-based matrix operations using OpenCV.
  - New `choose_matmul_type` function to determine matrix multiplication types.

- **Documentation**
  - Updated README with OpenCV usage examples and future plans.

- **Chores**
  - Updated `install.sh` script to optionally include OpenCV dependencies.

- **Refactor**
  - Optimized matrix data handling in `api_wrapper/matmul_api.hpp` with `memcpy` for improved performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->